### PR TITLE
fix: heroku gql deploy

### DIFF
--- a/src/queries/first20Gen1Query.ts
+++ b/src/queries/first20Gen1Query.ts
@@ -1,6 +1,4 @@
-import GqlTag from 'gql-tag';
-// import gql from 'graphql-tag';
-const gql = (GqlTag as any).default || GqlTag;
+import gql from './utils/gqlTag';
 
 const first20Gen1Query = gql`
   query First20Gen1($id: Int!) {

--- a/src/queries/first20Gen1Query.ts
+++ b/src/queries/first20Gen1Query.ts
@@ -1,4 +1,6 @@
-import gql from 'gql-tag';
+import GqlTag from 'gql-tag';
+// import gql from 'graphql-tag';
+const gql = (GqlTag as any).default || GqlTag;
 
 const first20Gen1Query = gql`
   query First20Gen1($id: Int!) {

--- a/src/queries/pokemonQuery.ts
+++ b/src/queries/pokemonQuery.ts
@@ -1,6 +1,4 @@
-import GqlTag from 'gql-tag';
-// import gql from 'graphql-tag';
-const gql = (GqlTag as any).default || GqlTag;
+import gql from './utils/gqlTag';
 
 const pokemonQuery = gql`
   query Pokemon($id: String!) {

--- a/src/queries/pokemonQuery.ts
+++ b/src/queries/pokemonQuery.ts
@@ -1,4 +1,6 @@
-import gql from 'gql-tag';
+import GqlTag from 'gql-tag';
+// import gql from 'graphql-tag';
+const gql = (GqlTag as any).default || GqlTag;
 
 const pokemonQuery = gql`
   query Pokemon($id: String!) {

--- a/src/queries/utils/gqlTag.ts
+++ b/src/queries/utils/gqlTag.ts
@@ -1,0 +1,10 @@
+/**
+ * Workaround for error when running `vite build`
+ * `TypeError: gql is not a function`
+ * https://github.com/vitejs/vite/issues/5694#issuecomment-976098129
+ */
+import GqlTag from 'gql-tag';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gql = (GqlTag as any).default || GqlTag;
+
+export default gql;


### PR DESCRIPTION
Fixes #20

Seeing `TypeError: gql is not a function` when running `vite build`, which was causing a problem when deploying ([logs](https://dashboard.heroku.com/apps/svelte-pokedex/activity/builds/7ed13aae-a1c6-431b-a46c-88375a1d655d)).

Uses solution from https://github.com/vitejs/vite/issues/5694#issuecomment-976098129