### PR TITLE
style: pokemon name route

### DIFF
--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -80,6 +80,11 @@
     @apply gap-4;
   }
 
+  li {
+    @apply text-sm;
+    @apply p-1;
+  }
+
   .list-types {
     grid-template-columns: repeat(var(--num-types), minmax(0, 1fr));
   }

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -12,7 +12,10 @@
 
 <section style="--card-bg-color: {TYPE_COLOR_LOOKUP[types[0].type.name].color}">
   <div>
-    <h1>{id}. {name}</h1>
+    <h1>
+      <span>{name}</span>
+      <span>#{id}</span>
+    </h1>
 
     {#if image}
       <img src={image} alt={`${name}`} />
@@ -70,6 +73,9 @@
   h1 {
     @apply m-0;
     @apply text-lg;
+
+    @apply flex;
+    @apply justify-between;
   }
 
   .card-h2 {
@@ -96,11 +102,11 @@
     grid-template-columns: repeat(var(--num-types), minmax(0, 1fr));
   }
   .list-types li {
-    background-color: var(--type-bg-color);
-    color: var(--type-text-color);
+    @apply p-1;
     @apply rounded-sm;
     @apply text-center;
-    @apply p-1;
+    background-color: var(--type-bg-color);
+    color: var(--type-text-color);
   }
 
   .list-evolution {

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -90,7 +90,6 @@
 
   li {
     @apply text-sm;
-    @apply p-1;
   }
 
   .list-types {
@@ -101,19 +100,21 @@
     color: var(--type-text-color);
     @apply rounded-sm;
     @apply text-center;
+    @apply p-1;
   }
 
   .list-evolution {
     grid-template-columns: repeat(var(--num-evolution), minmax(0, 1fr));
   }
   .list-evolution li {
+    @apply relative;
     @apply rounded-sm;
     @apply text-center;
-    @apply relative;
 
     @apply after:content-['→'];
     @apply after:absolute;
-    @apply after:-right-4;
+    @apply after:-right-3.5;
+    @apply after:font-normal;
 
     @apply last-of-type:after:content-none;
 

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -10,7 +10,7 @@
   export let description: string = '';
 </script>
 
-<section>
+<section style="--card-bg-color: {TYPE_COLOR_LOOKUP[types[0].type.name].color}">
   <div>
     <h1>{id}. {name}</h1>
 
@@ -38,8 +38,10 @@
     {#if evolution.length}
       <h2 class="card-h2">Evolution</h2>
       <ol class="list-evolution" style="--num-evolution: {evolution.length}">
-        {#each evolution as name}
-          <li>{capitalizeFirstLetter(name)}</li>
+        {#each evolution as stageName}
+          <li style="--evolution-weight: {stageName.toLowerCase() === name.toLowerCase() ? 'bold' : 'normal'}">
+            {capitalizeFirstLetter(stageName)}
+          </li>
         {/each}
       </ol>
     {/if}
@@ -53,16 +55,16 @@
 
 <style lang="postcss">
   section {
-    max-width: 350px;
     @apply mx-auto;
     @apply p-4;
-    @apply bg-amber-300;
     @apply rounded-lg;
+    max-width: 350px;
+    background: var(--card-bg-color);
   }
 
   div {
     @apply p-4;
-    @apply bg-white;
+    background-color: rgba(255, 255, 255, 0.75);
   }
 
   h1 {
@@ -105,7 +107,6 @@
     grid-template-columns: repeat(var(--num-evolution), minmax(0, 1fr));
   }
   .list-evolution li {
-    background-color: gray;
     @apply rounded-sm;
     @apply text-center;
     @apply relative;
@@ -115,6 +116,8 @@
     @apply after:-right-4;
 
     @apply last-of-type:after:content-none;
+
+    font-weight: var(--evolution-weight);
   }
 
   .description {

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Type } from 'src/types';
-  import { capitalizeFirstLetter } from 'utils';
+  import { capitalizeFirstLetter, TYPE_COLOR_LOOKUP } from 'utils';
 
   export let id: number;
   export let name: string;
@@ -8,8 +8,6 @@
   export let types: Type[] = [];
   export let evolution: string[] = [];
   export let description: string = '';
-
-  // const gridTemplateColumns = `repeat(${types.length}, minmax(0, 1fr))`;
 </script>
 
 <section>
@@ -24,7 +22,15 @@
       <h2 class="card-h2">Types</h2>
       <ul class="list-types" style="--num-types: {types.length}">
         {#each types as { type }}
-          <li>{capitalizeFirstLetter(type.name)}</li>
+          <li
+            style="--type-bg-color: {TYPE_COLOR_LOOKUP[type.name].color}; --type-text-color: {TYPE_COLOR_LOOKUP[
+              type.name
+            ].dark
+              ? '#fff'
+              : '#000'}"
+          >
+            {capitalizeFirstLetter(type.name)}
+          </li>
         {/each}
       </ul>
     {/if}
@@ -89,7 +95,8 @@
     grid-template-columns: repeat(var(--num-types), minmax(0, 1fr));
   }
   .list-types li {
-    background-color: gray;
+    background-color: var(--type-bg-color);
+    color: var(--type-text-color);
     @apply rounded-sm;
     @apply text-center;
   }

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -8,33 +8,104 @@
   export let types: Type[] = [];
   export let evolution: string[] = [];
   export let description: string = '';
+
+  // const gridTemplateColumns = `repeat(${types.length}, minmax(0, 1fr))`;
 </script>
 
-<h1>{id}. {name}</h1>
+<section>
+  <div>
+    <h1>{id}. {name}</h1>
 
-{#if image}
-  <img src={image} alt={`${name}`} />
-{/if}
+    {#if image}
+      <img src={image} alt={`${name}`} />
+    {/if}
 
-{#if types.length}
-  <h2>Types</h2>
-  <ul>
-    {#each types as { type }}
-      <li>{capitalizeFirstLetter(type.name)}</li>
-    {/each}
-  </ul>
-{/if}
+    {#if types.length}
+      <h2 class="card-h2">Types</h2>
+      <ul class="list-types" style="--num-types: {types.length}">
+        {#each types as { type }}
+          <li>{capitalizeFirstLetter(type.name)}</li>
+        {/each}
+      </ul>
+    {/if}
 
-{#if evolution.length}
-  <h2>Evolution</h2>
-  <ol>
-    {#each evolution as name}
-      <li>{capitalizeFirstLetter(name)}</li>
-    {/each}
-  </ol>
-{/if}
+    {#if evolution.length}
+      <h2 class="card-h2">Evolution</h2>
+      <ol class="list-evolution" style="--num-evolution: {evolution.length}">
+        {#each evolution as name}
+          <li>{capitalizeFirstLetter(name)}</li>
+        {/each}
+      </ol>
+    {/if}
 
-{#if description}
-  <h2>Description</h2>
-  <p>{description}</p>
-{/if}
+    {#if description}
+      <h2 class="card-h2">Description</h2>
+      <p class="description">{description}</p>
+    {/if}
+  </div>
+</section>
+
+<style lang="postcss">
+  section {
+    max-width: 350px;
+    @apply mx-auto;
+    @apply p-4;
+    @apply bg-amber-300;
+    @apply rounded-lg;
+  }
+
+  div {
+    @apply p-4;
+    @apply bg-white;
+  }
+
+  h1 {
+    @apply m-0;
+    @apply text-lg;
+  }
+
+  .card-h2 {
+    @apply text-sm;
+  }
+
+  img {
+    @apply block;
+    @apply w-3/4;
+    @apply mx-auto;
+  }
+
+  .list-types,
+  .list-evolution {
+    @apply grid;
+    @apply gap-4;
+  }
+
+  .list-types {
+    grid-template-columns: repeat(var(--num-types), minmax(0, 1fr));
+  }
+  .list-types li {
+    background-color: gray;
+    @apply rounded-sm;
+    @apply text-center;
+  }
+
+  .list-evolution {
+    grid-template-columns: repeat(var(--num-evolution), minmax(0, 1fr));
+  }
+  .list-evolution li {
+    background-color: gray;
+    @apply rounded-sm;
+    @apply text-center;
+    @apply relative;
+
+    @apply after:content-['→'];
+    @apply after:absolute;
+    @apply after:-right-4;
+
+    @apply last-of-type:after:content-none;
+  }
+
+  .description {
+    @apply text-sm;
+  }
+</style>

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -40,7 +40,9 @@
 
   a {
     @apply grid;
-    @apply grid-cols-12;
+    @apply grid-cols-6;
+    @apply sm:grid-cols-12;
+
     @apply text-cyan-800;
     @apply hover:underline;
   }
@@ -49,12 +51,16 @@
     @apply inline-flex;
     @apply items-center;
 
-    @apply first-of-type:col-span-9;
+    @apply first-of-type:col-span-4;
+    @apply sm:first-of-type:col-span-9;
+
     @apply last-of-type:col-span-1;
   }
 
   img {
     @apply h-14;
-    @apply col-span-2;
+
+    @apply col-span-1;
+    @apply sm:col-span-2;
   }
 </style>

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -43,4 +43,8 @@
     @apply inline-flex;
     @apply items-center;
   }
+
+  img {
+    @apply h-14;
+  }
 </style>

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -17,6 +17,7 @@
           <a href={`/pokemon/${name}`} target="_blank">
             <span>{id}. {capitalizeFirstLetter(name)}</span>
             <img src={image} alt={name} />
+            <span class="col-span-1">⤴</span>
           </a>
         </p>
       </li>
@@ -31,20 +32,29 @@
     @apply px-2;
     @apply py-1;
     @apply mb-2;
+
+    @apply shadow-sm;
+    @apply shadow-slate-500;
+    @apply hover:shadow-none;
   }
 
   a {
-    @apply flex;
-    @apply flex-row;
-    @apply justify-between;
+    @apply grid;
+    @apply grid-cols-12;
+    @apply text-cyan-800;
+    @apply hover:underline;
   }
 
   span {
     @apply inline-flex;
     @apply items-center;
+
+    @apply first-of-type:col-span-9;
+    @apply last-of-type:col-span-1;
   }
 
   img {
     @apply h-14;
+    @apply col-span-2;
   }
 </style>

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -40,7 +40,7 @@
 
   a {
     @apply grid;
-    @apply grid-cols-6;
+    @apply grid-cols-10;
     @apply sm:grid-cols-12;
 
     @apply text-cyan-800;
@@ -51,7 +51,7 @@
     @apply inline-flex;
     @apply items-center;
 
-    @apply first-of-type:col-span-4;
+    @apply first-of-type:col-span-7;
     @apply sm:first-of-type:col-span-9;
 
     @apply last-of-type:col-span-1;
@@ -60,7 +60,6 @@
   img {
     @apply h-14;
 
-    @apply col-span-1;
-    @apply sm:col-span-2;
+    @apply col-span-2;
   }
 </style>

--- a/src/components/Selection/Dropdown.svelte
+++ b/src/components/Selection/Dropdown.svelte
@@ -83,8 +83,15 @@
     @apply rounded;
   }
 
+  select {
+    @apply cursor-pointer;
+  }
+
   button {
     @apply bg-cyan-800;
     @apply text-white;
+    @apply shadow-md;
+    @apply shadow-slate-500;
+    @apply hover:shadow-none;
   }
 </style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -35,6 +35,11 @@
     @apply text-center;
   }
 
+  div {
+    @apply mx-auto;
+    max-width: 1200px;
+  }
+
   @media screen(sm) {
     div {
       @apply grid;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -35,7 +35,7 @@
     @apply text-center;
   }
 
-  @media (min-width: 640px) {
+  @media screen(sm) {
     div {
       @apply grid;
       @apply grid-cols-2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,10 @@ export interface Summary extends Identifiers {
 export interface PokemonLookup {
   [key: Summary['name']]: Summary;
 }
+
+export interface TypeColorLookup {
+  [key: string]: {
+    color: string;
+    dark: boolean;
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ interface Identifiers {
   name: string;
 }
 
-interface Specy {
+export interface Specy {
   pokemon: {
     id: number;
     name: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,9 @@
 // TODO test
-import type { Specy, PokemonLookupGQL } from 'src/types';
+import type { Specy, PokemonLookup } from 'src/types';
 
 // todo jsdoc
 export const createLookupByNameGql = (entries: Specy[]) => {
-  return entries.reduce<PokemonLookupGQL>((acc, entry) => {
+  return entries.reduce<PokemonLookup>((acc, entry) => {
     const { pokemon } = entry;
     const { id, name, forms } = pokemon[0];
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,11 @@
 // TODO test
-import type { Specy, PokemonLookup } from 'src/types';
+import type { Specy, PokemonLookup, TypeColorLookup } from 'src/types';
 
-// todo jsdoc
+/**
+ * Given a species array, return a lookup table by pokemon name
+ * @param entries
+ * @returns
+ */
 export const createLookupByNameGql = (entries: Specy[]) => {
   return entries.reduce<PokemonLookup>((acc, entry) => {
     const { pokemon } = entry;
@@ -29,3 +33,86 @@ export const capitalizeFirstLetter = (str: string) => {
   const rest = str.slice(1);
   return `${firstLetter.toUpperCase()}${rest}`;
 };
+
+export const TYPE_COLOR_LOOKUP: TypeColorLookup = {
+  normal: {
+    color: '#eeeeee',
+    dark: false,
+  },
+  fighting: {
+    color: '#e08026',
+    dark: false,
+  },
+  flying: {
+    color: '#68c8f1',
+    dark: false,
+  },
+  poison: {
+    color: '#5a0990',
+    dark: true,
+  },
+  ground: {
+    color: '#5d2510',
+    dark: true,
+  },
+  rock: {
+    color: '#383737',
+    dark: true,
+  },
+  bug: {
+    color: '#04583f',
+    dark: true,
+  },
+  ghost: {
+    color: '#1d1d1d',
+    dark: true,
+  },
+  steel: {
+    color: '#969494',
+    dark: false,
+  },
+  fire: {
+    color: '#eb3d1b',
+    dark: true,
+  },
+  water: {
+    color: '#1b91eb',
+    dark: false,
+  },
+  grass: {
+    color: '#03ab78',
+    dark: false,
+  },
+  electric: {
+    color: '#fbf83f',
+    dark: false,
+  },
+  psychic: {
+    color: '#2b0990',
+    dark: true,
+  },
+  ice: {
+    color: '#1db6f8',
+    dark: false,
+  },
+  dragon: {
+    color: '#1d57f8',
+    dark: true,
+  },
+  dark: {
+    color: '#000000',
+    dark: true,
+  },
+  fairy: {
+    color: '#dddddd',
+    dark: false,
+  },
+  unknown: {
+    color: '#c1b6b6',
+    dark: false,
+  },
+  shadow: {
+    color: '#474545',
+    dark: true,
+  },
+} as const;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,6 +34,10 @@ export const capitalizeFirstLetter = (str: string) => {
   return `${firstLetter.toUpperCase()}${rest}`;
 };
 
+/**
+ * Lookup table to associate a Pokemon's type with a color
+ * and whether that color is considered dark
+ */
 export const TYPE_COLOR_LOOKUP: TypeColorLookup = {
   normal: {
     color: '#eeeeee',


### PR DESCRIPTION
Resolves #11 
- creates lookup table of types:color

Also styles the Seen list further:
- make links look more clickable and have better spacing

## Feats

- Styled as pokemon card
- Card color depends on type
- evolution chain bolds the current pokemon

### Examples
<details>
  <summary>Ivysaur (multiple types)</summary>
  <img width="612" alt="Screen Shot 2022-08-10 at 12 58 58 AM" src="https://user-images.githubusercontent.com/11896191/183819411-557ef56e-6b4c-4f43-9bb9-86bffdab915d.png">

</details>

<details>
  <summary>Koffing (only 1 type)</summary>
  <img width="649" alt="Screen Shot 2022-08-10 at 12 56 47 AM" src="https://user-images.githubusercontent.com/11896191/183819133-e520713d-8675-4dd6-a2c8-f5d4fdbaa7ee.png">
</details>

