### PR TITLE
fix: style for long evolution chain

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,4 +26,10 @@
     @apply text-xl;
     @apply font-bold;
   }
+
+  a {
+    @apply text-cyan-800;
+    @apply underline;
+    @apply hover:no-underline;
+  }
 }

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -140,12 +140,6 @@
     font-weight: var(--evolution-weight);
   }
 
-  .list-evolution li a {
-    @apply text-cyan-800;
-    @apply underline;
-    @apply hover:no-underline;
-  }
-
   .description {
     @apply text-base;
   }

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -40,7 +40,12 @@
 
     {#if evolutions.length > 1}
       <h2 class="card-h2">Evolution</h2>
-      <ol class="list-evolution" style="--num-evolutions: {evolutions.length}">
+      <ol
+        class="list-evolution"
+        style="
+          --num-evolutions: {evolutions.length <= 3 ? evolutions.length : 3}
+        "
+      >
         {#each evolutions as evolution}
           <li style="--evolution-weight: {evolution.toLowerCase() === name.toLowerCase() ? 'bold' : 'normal'}">
             {#if evolution === name}

--- a/src/components/Card/index.svelte
+++ b/src/components/Card/index.svelte
@@ -121,12 +121,12 @@
   }
 
   .list-evolution {
+    @apply gap-y-1;
     grid-template-columns: repeat(var(--num-evolutions), minmax(0, 1fr));
   }
 
   .list-evolution li {
     @apply relative;
-    @apply rounded-sm;
     @apply text-center;
 
     /* right arrow */

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -49,9 +49,9 @@
     @apply grid-cols-10;
     @apply sm:grid-cols-12;
 
-    @apply text-cyan-800;
+    /* @apply text-cyan-800;
     @apply underline;
-    @apply hover:no-underline;
+    @apply hover:no-underline; */
   }
 
   span {

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -50,7 +50,8 @@
     @apply sm:grid-cols-12;
 
     @apply text-cyan-800;
-    @apply hover:underline;
+    @apply underline;
+    @apply hover:no-underline;
   }
 
   span {

--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -48,10 +48,6 @@
     @apply grid;
     @apply grid-cols-10;
     @apply sm:grid-cols-12;
-
-    /* @apply text-cyan-800;
-    @apply underline;
-    @apply hover:no-underline; */
   }
 
   span {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -27,9 +27,4 @@
     @apply bg-slate-300;
     @apply text-xs;
   }
-
-  footer a {
-    @apply text-cyan-800;
-    @apply underline;
-  }
 </style>


### PR DESCRIPTION
Resolves #51 

For evolution chains longer than 3, specify number of columns as 3.

## Before
<img width="455" alt="Screen Shot 2022-08-12 at 4 52 47 PM" src="https://user-images.githubusercontent.com/11896191/184443313-19e65b9e-ea8c-4197-9244-6b89d9e563de.png">

## After
<img width="436" alt="Screen Shot 2022-08-12 at 4 53 54 PM" src="https://user-images.githubusercontent.com/11896191/184443460-3bc232b5-d17b-46a3-a8ac-25ff94b369b8.png"> 
