### PR TITLE
ci: create setup workflow and make lint depend on it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@
 name: lint
 
 on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
   workflow_run:
     workflows: [setup]
     branches: [main]
@@ -21,9 +25,9 @@ jobs:
   # setup:
   #   uses: ./.github/workflows/setup.yml
   eslint:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,12 +34,11 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: echo 'The triggering workflow passed'
-    # steps:
-    #   - uses: actions/checkout@v3
-    #   - name: Use Node.js ${{ matrix.node-version }}
-    #     uses: actions/setup-node@v3
-    #     with:
-    #       node-version: ${{ matrix.node-version }}
-    #       cache: 'npm'
-    #   - run: npx eslint .
+      # - run: npx eslint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,8 @@ on:
     branches: ['main']
   workflow_run:
     workflows: [setup]
-    branches: [main]
-    types:
-      - completed
+    # branches: [main]
+    types: [completed]
 
 # on:
 #   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: lint
 
 on:
   workflow_run:
-    workflows: ['setup']
+    workflows: [setup]
     branches: [main]
     types:
       - completed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,13 @@
 name: lint
 
 on:
-  # push:
-  #   branches: ['main']
+  push:
+    branches: ['main']
   pull_request:
     branches: ['main']
   workflow_run:
     workflows: [setup]
-    branches-ignore: [main]
+    branches: [main]
     types: [completed]
 
 # on:
@@ -27,14 +27,14 @@ jobs:
     # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }
+
+    strategy:
+      matrix:
+        node-version: [16.16.0]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
     steps:
       - run: echo 'The triggering workflow passed'
-
-    # strategy:
-    #   matrix:
-    #     node-version: [16.16.0]
-    #     # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     # steps:
     #   - uses: actions/checkout@v3
     #   - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
     branches: ['main']
   workflow_run:
     workflows: [setup]
-    branches: [main]
+    # branches: [main]
     types: [completed]
 
 # on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ name: lint
 on:
   # push:
   #   branches: ['main']
-  # pull_request:
-  #   branches: ['main']
+  pull_request:
+    branches: ['main']
   workflow_run:
     workflows: [setup]
     branches-ignore: [main]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,11 @@ on:
 #     branches: ['main']
 
 jobs:
-  if: ${{ github.event.workflow_run.conclusion == 'success' }}
   # reference the setup workflow
   # setup:
   #   uses: ./.github/workflows/setup.yml
   eslint:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them,
-# and run lint jobs
+# This workflow will run lint jobs
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: lint
@@ -11,7 +10,11 @@ on:
     branches: ['main']
 
 jobs:
+  # reference the setup workflow
+  setup:
+    uses: ./.github/workflows/setup.yml
   eslint:
+    needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
 
     strategy:
@@ -26,5 +29,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
       - run: npx eslint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,17 @@
 name: lint
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  workflow_run:
+    workflows: ['setup']
+    branches: [main]
+    types:
+      - completed
+
+# on:
+#   push:
+#     branches: ['main']
+#   pull_request:
+#     branches: ['main']
 
 jobs:
   # reference the setup workflow

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,10 @@
 name: lint
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  # push:
+  #   branches: ['main']
+  # pull_request:
+  #   branches: ['main']
   workflow_run:
     workflows: [setup]
     # branches: [main]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
-# This workflow will run lint jobs
+# This workflow will do a clean installation of node dependencies, cache/restore them,
+# and run lint jobs
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: lint
@@ -11,9 +12,6 @@ on:
 
 jobs:
   eslint:
-    # run npm ci first
-    uses: ./.github/workflows/setup.yml
-    needs: [setup]
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,4 +26,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: npm ci
       - run: npx eslint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,18 +27,20 @@ jobs:
   eslint:
     # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
-    strategy:
-      matrix:
-        node-version: [16.16.0]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - run: npx eslint .
+      - run: echo 'The triggering workflow passed'
+
+    # strategy:
+    #   matrix:
+    #     node-version: [16.16.0]
+    #     # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    # steps:
+    #   - uses: actions/checkout@v3
+    #   - name: Use Node.js ${{ matrix.node-version }}
+    #     uses: actions/setup-node@v3
+    #     with:
+    #       node-version: ${{ matrix.node-version }}
+    #       cache: 'npm'
+    #   - run: npx eslint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
   #   branches: ['main']
   workflow_run:
     workflows: [setup]
-    # branches: [main]
+    branches-ignore: [main]
     types: [completed]
 
 # on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,12 @@ on:
 #     branches: ['main']
 
 jobs:
+  if: ${{ github.event.workflow_run.conclusion == 'success' }}
   # reference the setup workflow
-  setup:
-    uses: ./.github/workflows/setup.yml
+  # setup:
+  #   uses: ./.github/workflows/setup.yml
   eslint:
-    needs: [setup] # make the setup workflow a dependency
+    # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
-# This workflow will run lint jobs
+# This workflow will do a clean installation of node dependencies, cache/restore them,
+# and run lint jobs
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: lint
@@ -8,25 +9,10 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
-  workflow_run:
-    workflows: [setup]
-    # branches: [main]
-    types: [completed]
-
-# on:
-#   push:
-#     branches: ['main']
-#   pull_request:
-#     branches: ['main']
 
 jobs:
-  # reference the setup workflow
-  # setup:
-  #   uses: ./.github/workflows/setup.yml
   eslint:
-    # needs: [setup] # make the setup workflow a dependency
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }
 
     strategy:
       matrix:
@@ -40,5 +26,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: echo 'The triggering workflow passed'
-      # - run: npx eslint .
+      - run: npm ci
+      - run: npx eslint .

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -4,8 +4,8 @@
 
 name: setup
 
-on:
-  on: [workflow_call]
+# allow this workflow to be called from other workflows
+on: [workflow_call]
 
 jobs:
   npm_ci:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -4,8 +4,14 @@
 
 name: setup
 
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
 # allow this workflow to be called from other workflows
-on: [workflow_call]
+# on: [workflow_call]
 
 jobs:
   npm_ci:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,19 +1,14 @@
-# This workflow will run lint jobs
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+# This workflow does a clean installation of node dependencies, and cache/restore them.
+# It is meant to be called in other workflows as a first step.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_call
 
-name: lint
+name: setup
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  on: [workflow_call]
 
 jobs:
-  eslint:
-    # run npm ci first
-    uses: ./.github/workflows/setup.yml
-    needs: [setup]
+  npm_ci:
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,4 +23,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npx eslint .
+      - run: npm ci

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,45 @@
+# This workflow will run lint jobs
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: wip
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  workflow_run:
+    workflows: [setup]
+    branches: [main]
+    types:
+      - completed
+
+# on:
+#   push:
+#     branches: ['main']
+#   pull_request:
+#     branches: ['main']
+
+jobs:
+  # reference the setup workflow
+  # setup:
+  #   uses: ./.github/workflows/setup.yml
+  eslint:
+    # needs: [setup] # make the setup workflow a dependency
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }
+
+    strategy:
+      matrix:
+        node-version: [16.16.0]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: echo 'The triggering workflow passed'
+      # - run: npx eslint .


### PR DESCRIPTION
Resolves #87 

According to https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run, the new `setup` workflow will only trigger a run if the config file is on the default branch (aka, `main`). So will have to merge this in first and use a follow up PR to further refine.