### PR TITLE
fix: create util to provide full URL for sprites

### DIFF
--- a/src/components/Seen/List.svelte
+++ b/src/components/Seen/List.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { seenPokemon } from 'src/stores';
   import type { PokemonLookup } from 'src/types';
-  import { capitalizeFirstLetter } from 'utils';
+  import { capitalizeFirstLetter, getFullImageUrl } from 'utils';
 
   let pokemons: PokemonLookup = {};
 
@@ -20,9 +20,9 @@
     {#each pokemonsList as { id, name, image }}
       <li>
         <p>
-          <a href={`/pokemon/${name}`} target="_blank">
+          <a href={`/pokemon/${name}`} target="_blank" rel="noreferrer">
             <span class="id-name">{id}. {capitalizeFirstLetter(name)}</span>
-            <img src={image} alt={name} />
+            <img src={getFullImageUrl(image)} alt={name} />
             <!-- use html entities to create open in new tab icon -->
             <span aria-hidden="true" class="link-icon">
               <span>&#9744</span><!-- ☐ -->

--- a/src/components/Seen/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/components/Seen/__tests__/__snapshots__/index.test.ts.snap
@@ -18,6 +18,7 @@ exports[`Card renders a list of seen pokemon 1`] = `
             <a
               class="svelte-gtgtc4"
               href="/pokemon/Fake1"
+              rel="noreferrer"
               target="_blank"
             >
               <span
@@ -61,6 +62,7 @@ exports[`Card renders a list of seen pokemon 1`] = `
             <a
               class="svelte-gtgtc4"
               href="/pokemon/Fake2"
+              rel="noreferrer"
               target="_blank"
             >
               <span
@@ -104,6 +106,7 @@ exports[`Card renders a list of seen pokemon 1`] = `
             <a
               class="svelte-gtgtc4"
               href="/pokemon/Fake3"
+              rel="noreferrer"
               target="_blank"
             >
               <span

--- a/src/network/__tests__/index.test.ts
+++ b/src/network/__tests__/index.test.ts
@@ -11,7 +11,7 @@ jest.mock('axios', () => {
 });
 
 describe('fetchGraphQL', () => {
-  it('makes a POST request with the require GQL payload', async () => {
+  it('makes a POST request with the required GQL payload', async () => {
     const payload = {
       query: 'mock query string',
       variables: {

--- a/src/routes/pokemon/[name=name]/index.svelte
+++ b/src/routes/pokemon/[name=name]/index.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/stores';
   import type { PokemonQueryResponse, Type } from 'src/types';
   import pokemonQuery from 'src/queries/pokemonQuery';
-  import { capitalizeFirstLetter } from 'utils';
+  import { capitalizeFirstLetter, getFullImageUrl } from 'utils';
   import { fetchGraphQL } from 'network';
 
   import Card from 'components/Card/index.svelte';
@@ -38,7 +38,7 @@
     ({ id, types } = pokemon[0]);
     const { species, images } = pokemon[0];
 
-    image = JSON.parse(images[0].sprites).front_default;
+    image = getFullImageUrl(JSON.parse(images[0].sprites).front_default);
 
     const { descriptions, evolutionChain } = species;
 

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import type { Specy } from 'src/types';
-import { createLookupByName, capitalizeFirstLetter } from '..';
+import { createLookupByName, capitalizeFirstLetter, IMAGE_HOST_DIR, getFullImageUrl } from '..';
 
 describe('createLookupByName', () => {
   it('returns an empty object if entries is empty', () => {
@@ -107,5 +107,21 @@ describe('capitalizeFirstLetter', () => {
     const result = capitalizeFirstLetter(input);
 
     expect(result).toBe('Lowercase something');
+  });
+});
+
+describe('getFullImageUrl', () => {
+  it('replaces the media folder in the path with the full image host directory', () => {
+    const folder = '/media/some/image.png';
+    const result = getFullImageUrl(folder);
+
+    expect(result.startsWith(IMAGE_HOST_DIR)).toBe(true);
+  });
+
+  it('returns the given image path undisturbed if it is not in the media folder', () => {
+    const folder = '/not/in/media/image.png';
+    const result = getFullImageUrl(folder);
+
+    expect(result).toBe(folder);
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,16 +35,18 @@ export const capitalizeFirstLetter = (str: string) => {
   return `${firstLetter.toUpperCase()}${rest}`;
 };
 
+export const IMAGE_HOST_DIR = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/';
+
 /**
  * Get the full image URL for a given sprite path like
  * `/media/sprites/pokemon/3.png`
  * @param image 
  */
 export const getFullImageUrl = (image: string) => {
-  return image.replace(
-    '/media/',
-    'https://raw.githubusercontent.com/PokeAPI/sprites/master/',
-  );
+  if (image.startsWith('/media/')) {
+    return image.replace('/media/', IMAGE_HOST_DIR);
+  }
+  return image;
 };
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,11 @@ export const capitalizeFirstLetter = (str: string) => {
   return `${firstLetter.toUpperCase()}${rest}`;
 };
 
+/**
+ * Get the full image URL for a given sprite path like
+ * `/media/sprites/pokemon/3.png`
+ * @param image 
+ */
 export const getFullImageUrl = (image: string) => {
   return image.replace(
     '/media/',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,13 @@ export const capitalizeFirstLetter = (str: string) => {
   return `${firstLetter.toUpperCase()}${rest}`;
 };
 
+export const getFullImageUrl = (image: string) => {
+  return image.replace(
+    '/media/',
+    'https://raw.githubusercontent.com/PokeAPI/sprites/master/',
+  );
+};
+
 /**
  * Lookup table to associate a Pokemon's type with a color
  * and whether that color is considered dark
@@ -121,3 +128,4 @@ export const TYPE_COLOR_LOOKUP: Readonly<TypeColorLookup> = {
     dark: true,
   },
 } as const;
+


### PR DESCRIPTION
The PokeAPI GQL response must've been updated so that the sprite's paths are no longer full URLs, but instead something like
```
/media/sprites/pokemon/9.png
```
causing the images to fail to load. Example:
<img width="324" alt="Screenshot 2023-03-16 at 1 05 28 AM" src="https://user-images.githubusercontent.com/11896191/225519978-8c6fa115-b6fb-4a60-958e-3a0c0c5ac3b1.png">
